### PR TITLE
Change zramsize to 512MB

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -16,4 +16,4 @@
 
 /devices/soc.0/7864900.sdhci/mmc_host*       auto        auto     defaults                                                    voldmanaged=sdcard1:auto,encryptable=userdata
 /devices/platform/msm_hsusb*                 auto        auto     defaults                                                    voldmanaged=usbdisk:auto
-/dev/block/zram0                             none        swap     defaults zramsize=268435456,max_comp_streams=4
+/dev/block/zram0                             none        swap     defaults zramsize=536870912,max_comp_streams=4


### PR DESCRIPTION
On 1GB variant, 512MB ZRAM makes the device performs better.